### PR TITLE
Make county dropdown display threshold configurable

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,15 +1,15 @@
-.m-notification .cf-icon-svg {
+#rental-assistance-finder .m-notification .cf-icon-svg {
   font-size: 1.125em;
 }
-.cf-icon-svg {
+#rental-assistance-finder .cf-icon-svg {
     height: 1.1875em;
     vertical-align: text-top;
     max-width: 1em;
 }
-.App {
+#rental-assistance-finder .App {
   max-width: 41.875rem;
 }
-.App dl a {
+#rental-assistance-finder .App dl a {
   word-break: break-all;
 }
 #rental-assistance-finder .m-form-field + .m-form-field {

--- a/src/App.js
+++ b/src/App.js
@@ -5,7 +5,7 @@ import { fetchPrograms, generateTribalOptions } from './utils.js';
 import RentalAssistanceFinder from './RentalAssistanceFinder.js';
 import Notification from "./Notification.js";
 
-function App() {
+function App( props ) {
   const [ data, setData ] = useState( {
     geographic: [],
     tribal: []
@@ -37,7 +37,8 @@ function App() {
           <div>
             { data.geographic.length ? 
               (
-                <RentalAssistanceFinder geographic={ data.geographic }
+                <RentalAssistanceFinder countyThreshold={ props.countyThreshold }
+                                        geographic={ data.geographic }
                                         tribal={ data.tribal }
                                         tribeOptions={ generateTribalOptions( data.tribal ) }/>
               ) : (

--- a/src/RentalAssistanceFinder.js
+++ b/src/RentalAssistanceFinder.js
@@ -12,7 +12,7 @@ function RentalAssistanceFinder( props ) {
   const tribalPrograms = filterTribalPrograms( props.tribal, state, tribe );
 
   const [ geographicPrograms, countyOptions ] = getGeographicData(
-    props.geographic, state, county, tribe
+    props.geographic, state, county, tribe, props.countyThreshold
   );
 
   const results = [].concat( geographicPrograms, tribalPrograms );

--- a/src/__tests__/utils.test.js
+++ b/src/__tests__/utils.test.js
@@ -4,6 +4,7 @@ import {
   filterProgramsByCounty,
   generateCountyOptions,
   generateTribalOptions, 
+  getGeographicData,
   sortGeographic,
   sortStatePrograms
 } from '../utils.js';
@@ -140,7 +141,7 @@ const allPrograms = [...geographicPrograms, ...tribalPrograms]
 describe('module::utils', () => {
 
   describe( 'filterTribalPrograms', () => {
-    it( 'returns result for tribe selection' , () => {
+    it( 'returns result for tribe selection', () => {
       const results = filterTribalPrograms( 
         tribalPrograms, 'Oklahoma', 'Caddo Nation'
       )
@@ -148,7 +149,7 @@ describe('module::utils', () => {
       expect( results[0] ).toEqual( tribalPrograms[1] )
     } );
 
-    it( 'returns no results for unmatched tribe selection' , () => {
+    it( 'returns no results for unmatched tribe selection', () => {
       const results = filterTribalPrograms( 
         tribalPrograms, 'Oklahoma', 'Nation'
       )
@@ -156,14 +157,14 @@ describe('module::utils', () => {
       expect( results.length ).toEqual( 0 );
     } );
 
-    it( 'returns no results when state but not tribe is selected' , () => {
+    it( 'returns no results when state but not tribe is selected', () => {
       const results = filterTribalPrograms( 
         tribalPrograms, 'California', ''
       )
       expect( results.length ).toEqual( 0 );
     } );
 
-    it( 'returns all results if no state or tribe is selected' , () => {
+    it( 'returns all results if no state or tribe is selected', () => {
       const results = filterTribalPrograms( 
         tribalPrograms, '', ''
       )
@@ -173,7 +174,7 @@ describe('module::utils', () => {
   } );
 
   describe( 'filterGeographicPrograms', () => {
-    it( 'returns results for state selection' , () => {
+    it( 'returns results for state selection', () => {
       const results = filterGeographicPrograms( 
         geographicPrograms, 'California', 'Caddo Nation'
       )
@@ -181,14 +182,14 @@ describe('module::utils', () => {
       expect( results[2].name ).toEqual( 'California' )
     } );
 
-    it( 'returns no results when tribe but not state is selected' , () => {
+    it( 'returns no results when tribe but not state is selected', () => {
       const results = filterGeographicPrograms( 
         geographicPrograms, '', 'Caddo Nation'
       )
       expect( results.length ).toEqual( 0 );
     } );
 
-    it( 'returns all results when neither tribe nor state is selected' , () => {
+    it( 'returns all results when neither tribe nor state is selected', () => {
       const results = filterGeographicPrograms( 
         geographicPrograms, '', ''
       )
@@ -198,7 +199,7 @@ describe('module::utils', () => {
   } );
 
   describe( 'generateTribalOptions', () => {
-    it( 'generates options for all tribes' , () => {
+    it( 'generates options for all tribes', () => {
       const options = generateTribalOptions( tribalPrograms );
       expect( options.length ).toEqual( 3 );
       expect( options[0] ).toEqual( tribalPrograms[0].name )
@@ -206,7 +207,7 @@ describe('module::utils', () => {
   } );
 
   describe( 'sortStatePrograms', () => {
-    it( 'sorts state results alphabetically by type and then name' , () => {
+    it( 'sorts state results alphabetically by type and then name', () => {
       const sorted = sortStatePrograms( statePrograms );
       expect( sorted.map( item => ( item.name ) ) ).toEqual(
         ['Fort Wayne', 'Indianapolis', 'Elkhart County',
@@ -217,25 +218,53 @@ describe('module::utils', () => {
   } );
 
   describe( 'sortGeographic', () => {
-    it( 'sorts cities alphabetically' , () => {
+    it( 'sorts cities alphabetically', () => {
       expect( sortGeographic(   
         {'name': 'Indianapolis', 'type': 'City'},
         {'name': 'Fort Wayne', 'type': 'City'}
       ) ).toEqual( 1 );
     } );
 
-    it( 'sorts cities then counties' , () => {
+    it( 'sorts cities then counties', () => {
       expect( sortGeographic(   
         {'name': 'Indianapolis', 'type': 'City'},
         {'name': 'Allen County', 'type': 'County'}
       ) ).toEqual( -1 );
     } );
 
-    it( 'sorts counties alphabetically' , () => {
+    it( 'sorts counties alphabetically', () => {
       expect( sortGeographic(   
         {'name': 'Lake County', 'type': 'County'},
         {'name': 'Allen County', 'type': 'County'}
       ) ).toEqual( 1 );
     } );
   } );
+
+  describe( 'getGeographicData', () => {
+    it( 'returns counties when county threshold met', () => {
+      const [ geographicResults, countyOptionResults ] = getGeographicData (  
+        statePrograms, 'Indiana', '', '', 5 
+      )
+      expect( countyOptionResults ).not.toEqual( [] );
+    } );
+    it( 'does not return counties when county threshold not met', () => {
+      const [ geographicResults, countyOptionResults ] = getGeographicData (  
+        statePrograms, 'Indiana', '', '', 20 
+      )
+      expect( countyOptionResults ).toEqual( [] );
+    } );
+    it( 'does not return counties when default county threshold of 10 not met', () => {
+      const [ geographicResults, countyOptionResults ] = getGeographicData (  
+        statePrograms, 'Indiana', '', '' 
+      )
+      expect( countyOptionResults ).toEqual( [] );
+    } );
+    it( 'does not return counties if no counties even if county threshold met', () => {
+      const [ geographicResults, countyOptionResults ] = getGeographicData (  
+        [{'name': 'Indiana', 'type': 'State'}], 'Indiana', '', '', 0 
+      )
+      expect( countyOptionResults ).toEqual( [] );
+    } );
+  } );
+
 })

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ if ( language === 'es' ) {
 
 ReactDOM.render(
   <React.StrictMode>
-    <App countyThreshold={ !isNaN( countyThreshold ) ? countyThreshold : undefined }/>
+    <App countyThreshold={ isNaN( countyThreshold ) ? undefined : countyThreshold }/>
   </React.StrictMode>,
   root
 );

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import App from './App';
 
 const root = document.getElementById('rental-assistance-finder');
 const language = root.getAttribute( 'data-language' );
-const countyThreshold = root.getAttribute( 'data-county-threshold' );
+const countyThreshold = parseInt( root.getAttribute( 'data-county-threshold' ) );
 
 if ( language === 'es' ) {
   i18n.changeLanguage( language );
@@ -17,7 +17,7 @@ if ( language === 'es' ) {
 
 ReactDOM.render(
   <React.StrictMode>
-    <App countyThreshold={ countyThreshold ? countyThreshold : undefined }/>
+    <App countyThreshold={ !isNaN( countyThreshold ) ? countyThreshold : undefined }/>
   </React.StrictMode>,
   root
 );

--- a/src/index.js
+++ b/src/index.js
@@ -9,14 +9,15 @@ import App from './App';
 
 const root = document.getElementById('rental-assistance-finder');
 const language = root.getAttribute( 'data-language' );
+const countyThreshold = root.getAttribute( 'data-county-threshold' );
 
 if ( language === 'es' ) {
   i18n.changeLanguage( language );
-} 
+}
 
 ReactDOM.render(
   <React.StrictMode>
-    <App/>
+    <App countyThreshold={ countyThreshold ? countyThreshold : undefined }/>
   </React.StrictMode>,
   root
 );

--- a/src/utils.js
+++ b/src/utils.js
@@ -45,7 +45,6 @@ export const filterTribalPrograms = ( programs, state, tribe ) => {
 
 export const generateCountyOptions = ( programs ) => {
   let counties = [];
-  let countyUnlisted = i18n.t( 'filters.county.unlisted' );
   programs.forEach( item => {
     if ( item.type === 'County' ) {
       counties.push( item.name );
@@ -54,7 +53,9 @@ export const generateCountyOptions = ( programs ) => {
     } 
   });
   counties = counties.filter( onlyUnique ).sort();
-  counties.unshift( countyUnlisted );
+  if ( counties.length > 0 ) {
+    counties.unshift( i18n.t( 'filters.county.unlisted' ) );
+  }
   return counties;
 }
 
@@ -70,11 +71,11 @@ export const filterProgramsByCounty = ( programs, county ) => {
   )
 }
 
-export const getGeographicData = ( programs, state, county, tribe ) => {
+export const getGeographicData = ( programs, state, county, tribe, countyThreshold = 10 ) => {
   let geographic = filterGeographicPrograms( programs, state, tribe );
   let countyOptions = [];
 
-  if ( state && geographic.length > 5 ) {
+  if ( state && geographic.length > countyThreshold ) {
     countyOptions = generateCountyOptions( geographic );
   }
 
@@ -85,7 +86,7 @@ export const getGeographicData = ( programs, state, county, tribe ) => {
   return [ geographic, countyOptions ];
 }
 
-export const fetchPrograms =  () => {
+export const fetchPrograms = () => {
   return fetch( 
     programsURL 
   ).then( 


### PR DESCRIPTION
Currently there is a hard-coded threshold of 5 results that determines whether the county dropdown displays for a state. This PR changes the default to 10 and makes the value configurable via a data attribute on the app's container element.

## Additions

- `index.js` accesses `data-county-threshold` attribute on container element and passes to App if it's a number
- new `countyThreshold` parameter in `getGeographicData` defaults to 10 and accepts prop passed in from data attribute
- Basic tests for `getGeographicData`

## Changes
- scope the CSS to the tool's container element


## Testing

1. Check out branch and run `yarn start`
2. Verify that county threshold now defaults to 10 (for instance, New Jersey should still show a county dropdown but not Arizona)
3. Add a `data-county-threshold` attribute to the container element in index.html. Verify that a numeric value replaces the default county threshold and a non-numeric value is replaced by the default threshold


## Todos

- Need more tests. Maybe move the data attribute check into utils?

## Notes
- Technically I guess we'd make the default 11 since one of the results will be the state and not provide a county value? Or if we're concerned about how many counties there are vs how many results, we could run the threshold check after building the countyOptions array. Not too worried about this for now if the value is configurable though

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
