### PR TITLE
Change prepare script to prepack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "erap-lookup",
+  "name": "@cfpb/rental-assistance-finder",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "node ./build-non-split.js",
-    "prepare": "cp build/static/js/main.js dist/ && cp build/static/css/main.*.css dist/",
+    "prepack": "cp build/static/js/main.js dist/ && cp build/static/css/main.*.css dist/",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
`prepare` runs on `npm install`, which causes an error.

`prepack` runs on `npm publish` and `npm pack` **only**, which is what we want.