### PR TITLE
Accessibility update

### DIFF
--- a/src/Filter.js
+++ b/src/Filter.js
@@ -16,6 +16,10 @@ const customStyles = {
     ...base,
     backgroundColor: '#919395',
     margin: 0
+  } ),
+  placeholder: base => ( {
+    ...base,
+    color: '#585d61'
   } )
 };
 


### PR DESCRIPTION
Increase contrast in dropdown placeholder text


## Changes

- Update dropdown placeholder text color

## Testing

1. Run WAVE Chrome extension against main branch and note contrast errors for placeholder text
2. Check out branch and `yarn start`
3. Run WAVE Chrome extension on page and verify no contrast errors

