### PR TITLE
Fix cypress testing logic for when states don't have statewide programs

### DIFF
--- a/cypress/integration/helpers.js
+++ b/cypress/integration/helpers.js
@@ -12,6 +12,7 @@ export const processData = ( programData ) => {
   const countyThreshold = 1;
   const stateData = {};
   const countyData = {};
+  const statewidePrograms = {}
   const programs = programData.geographic;
   // generate a map of states and their programs
   programs.forEach( program => {
@@ -19,6 +20,7 @@ export const processData = ( programData ) => {
     const stateArray = stateData[state] || [];
     stateArray.push( program );
     stateData[state] = stateArray;
+    if(program.type === 'State') statewidePrograms[state] = 1
   } );
   const states = Object.keys( stateData );
   // generate a map of states, their counties, and 
@@ -47,5 +49,5 @@ export const processData = ( programData ) => {
       })
     }
   } );
-  return [ stateData, countyData ];
+  return [ stateData, countyData, statewidePrograms ];
 }

--- a/cypress/integration/helpers.js
+++ b/cypress/integration/helpers.js
@@ -12,7 +12,7 @@ export const processData = ( programData ) => {
   const countyThreshold = 1;
   const stateData = {};
   const countyData = {};
-  const statewidePrograms = {}
+  const statewidePrograms = {};
   const programs = programData.geographic;
   // generate a map of states and their programs
   programs.forEach( program => {
@@ -20,7 +20,7 @@ export const processData = ( programData ) => {
     const stateArray = stateData[state] || [];
     stateArray.push( program );
     stateData[state] = stateArray;
-    if(program.type === 'State') statewidePrograms[state] = 1
+    if ( program.type === 'State' ) statewidePrograms[state] = 1;
   } );
   const states = Object.keys( stateData );
   // generate a map of states, their counties, and 

--- a/cypress/integration/verify-fixture-data.spec.js
+++ b/cypress/integration/verify-fixture-data.spec.js
@@ -1,5 +1,5 @@
 /* global cy, describe, beforeEach, it, expect */
-const fixtureData = require('../fixtures/programs.json');
+const fixtureData = require( '../fixtures/programs.json' );
 import { processData, selectOption } from './helpers.js';
 
 describe( 'Test results against fixture data', () => {
@@ -12,36 +12,39 @@ describe( 'Test results against fixture data', () => {
     );
     cy.visit( 'http://localhost:3000/' );
     cy.waitForReact();
-    cy.wait('@programJSON');
+    cy.wait( '@programJSON' );
   } );
 
-  const [ stateData, countyData ] = processData( fixtureData );
+  const [ stateData, countyData, statewidePrograms ] = processData( fixtureData );
   const states = Object.keys( stateData );
   states.forEach( state => {
     const statePrograms = stateData[state];
     const count = statePrograms.length;
-    const vals = statePrograms.map( program => program.name).join('; ');
-    it(`should show ${count} program${count > 1 ? "s" : ""} for ${state} -- (${vals})`, () => {
+    const statewideProgramCount = Number( Boolean( statewidePrograms[state] ) );
+    const vals = statePrograms.map( program => program.name ).join( '; ' );
+    it( `should show ${ count } program${ count > 1 ? 's' : '' } for ${ state } -- (${ vals })`, () => {
       selectOption( 'state-select', state );
-      cy.get('.result-item').should( 'have.length', count );
-    });
+      cy.get( '.result-item' ).should( 'have.length', count );
+    } );
     const programsByCounty = countyData[state];
     if ( programsByCounty ) {
       const counties = Object.keys( programsByCounty );
       counties.forEach( county => {
         const countyPrograms = programsByCounty[county];
-        const count = countyPrograms.length + 1;
-        const vals = countyPrograms.join('; ');
-        it(`should show ${count} programs for ${county}, ${state} -- (${vals}; ${state} state)`, () => {
+        const count = countyPrograms.length + statewideProgramCount;
+        const vals = countyPrograms.join( '; ' );
+        it( `should show ${ count } programs for ${ county }, ${ state } -- (${ vals }; ${ state } state)`, () => {
           selectOption( 'state-select', state );
           selectOption( 'county-select', county );
-          cy.get('.result-item').should( 'have.length', count );
-          cy.get('.result-item h3').contains( state ).should( 'exist' );
+          cy.get( '.result-item' ).should( 'have.length', count );
+          if ( statewideProgramCount ) {
+            cy.get( '.result-item h3' ).contains( state ).should( 'exist' );
+          }
           countyPrograms.forEach( program => {
-            cy.get('.result-item h3').contains( program ).should( 'exist' );
-          })
-        })
-      })
+            cy.get( '.result-item h3' ).contains( program ).should( 'exist' );
+          } );
+        } );
+      } );
     }
   } );
 } );

--- a/cypress/integration/verify-live-data.spec.js
+++ b/cypress/integration/verify-live-data.spec.js
@@ -5,36 +5,39 @@ describe( 'Test results against live data', () => {
   before( () => {
     cy.visit( 'http://localhost:3000/' );
     cy.waitForReact();
-  });
+  } );
 
-  const [ stateData, countyData ] = processData( programData );
+  const [ stateData, countyData, statewidePrograms ] = processData( programData );
   const states = Object.keys( stateData );
   states.forEach( state => {
     const statePrograms = stateData[state];
     const count = statePrograms.length;
-    const vals = statePrograms.map( program => program.name).join('; ');
-    it(`should show ${count} program${count > 1 ? "s" : ""} for ${state} -- (${vals})`, () => {
+    const statewideProgramCount = Number( Boolean( statewidePrograms[state] ) );
+    const vals = statePrograms.map( program => program.name ).join( '; ' );
+    it( `should show ${ count } program${ count > 1 ? 's' : '' } for ${ state } -- (${ vals })`, () => {
       selectOption( 'state-select', state );
-      cy.get('.result-item').should( 'have.length', count );
-    });
+      cy.get( '.result-item' ).should( 'have.length', count );
+    } );
     const programsByCounty = countyData[state];
     if ( programsByCounty ) {
       const counties = Object.keys( programsByCounty );
       counties.forEach( county => {
         const countyPrograms = programsByCounty[county];
-        const count = countyPrograms.length + 1;
-        const vals = countyPrograms.join('; ');
-        it(`should show ${count} programs for ${county}, ${state} -- (${vals}; ${state} state)`, () => {
+        const count = countyPrograms.length + statewideProgramCount;
+        const vals = countyPrograms.join( '; ' );
+        it( `should show ${ count } programs for ${ county }, ${ state } -- (${ vals }; ${ state } state)`, () => {
           selectOption( 'state-select', state );
           selectOption( 'county-select', county );
-          cy.get('.result-item').should( 'have.length', count );
-          cy.get('.result-item h3').contains( state ).should( 'exist' );
+          cy.get( '.result-item' ).should( 'have.length', count );
+          if ( statewideProgramCount ) {
+            cy.get( '.result-item h3' ).contains( state ).should( 'exist' );
+          }
           countyPrograms.forEach( program => {
-            cy.get('.result-item h3').contains( program ).should( 'exist' );
-          })
-        })
-      })
+            cy.get( '.result-item h3' ).contains( program ).should( 'exist' );
+          } );
+        } );
+      } );
     }
   } );
 
-});
+} );


### PR DESCRIPTION
In the live data, Texas no longer has a statewide program. The cypress tests currently assume states always do.

This fixes that (browser-tests should pass).